### PR TITLE
Add Supabase schema, WeChat login, and Drizzle ORM client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # chatlife
+
+Backend for LifeChat built on Supabase.
+
+## Supabase Setup
+
+- Initialize and link your project with `supabase init` and `supabase link --project-ref <PROJECT_REF>`.
+- Apply schema from `supabase/seed/001_init.sql` using `supabase db push`.
+- Deploy edge functions with `supabase functions deploy`, e.g. `wechat-login` for WeChat authentication.
+
+## Drizzle ORM
+
+Use [Drizzle ORM](https://orm.drizzle.team/) to query the Supabase database.
+Set `SUPABASE_DB_URL` to your project's connection string and import the client:
+
+```ts
+import { db, users } from './db/client';
+
+const result = await db.select().from(users);
+```

--- a/db/client.ts
+++ b/db/client.ts
@@ -1,0 +1,12 @@
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+
+const connectionString = process.env.SUPABASE_DB_URL;
+if (!connectionString) {
+  throw new Error('SUPABASE_DB_URL is not set');
+}
+
+const client = postgres(connectionString, { prepare: false });
+export const db = drizzle(client);
+
+export * from './schema';

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,0 +1,74 @@
+import { pgSchema, uuid, text, jsonb, timestamp, integer, bigserial, vector } from 'drizzle-orm/pg-core';
+
+const app = pgSchema('app');
+
+export const users = app.table('users', {
+  uid: uuid('uid').primaryKey(),
+  displayName: text('display_name'),
+  avatarUrl: text('avatar_url'),
+  locale: text('locale').default('en'),
+  tz: text('tz').default('Asia/Singapore'),
+  createdAt: timestamp('created_at').defaultNow(),
+});
+
+export const runs = app.table('runs', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  ownerUid: uuid('owner_uid').notNull(),
+  universe: text('universe').notNull(),
+  seedProfile: jsonb('seed_profile').notNull(),
+  state: jsonb('state').default('{}'),
+  version: text('version').default('v1'),
+  createdAt: timestamp('created_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow(),
+});
+
+export const chats = app.table('chats', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  runId: uuid('run_id').notNull(),
+  title: text('title'),
+  stage: text('stage'),
+  lastMessageAt: timestamp('last_message_at'),
+  createdAt: timestamp('created_at').defaultNow(),
+});
+
+export const messages = app.table('messages', {
+  id: bigserial('id', { mode: 'number' }).primaryKey(),
+  chatId: uuid('chat_id').notNull(),
+  role: text('role'),
+  content: text('content').notNull(),
+  meta: jsonb('meta'),
+  tokensIn: integer('tokens_in').default(0),
+  tokensOut: integer('tokens_out').default(0),
+  llmModel: text('llm_model'),
+  status: text('status').default('complete'),
+  createdAt: timestamp('created_at').defaultNow(),
+});
+
+export const npcs = app.table('npcs', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  universe: text('universe').notNull(),
+  archetype: text('archetype').notNull(),
+  persona: jsonb('persona').notNull(),
+  memoryVec: vector('memory_vec', { dimensions: 1536 }),
+  createdAt: timestamp('created_at').defaultNow(),
+});
+
+export const templates = app.table('templates', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  universe: text('universe').notNull(),
+  version: text('version').notNull(),
+  checksum: text('checksum'),
+  files: jsonb('files'),
+  createdAt: timestamp('created_at').defaultNow(),
+});
+
+export const relationships = app.table('relationships', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  runId: uuid('run_id').notNull(),
+  subjectType: text('subject_type').notNull(),
+  subjectId: uuid('subject_id').notNull(),
+  intimacy: integer('intimacy').default(0),
+  trust: integer('trust').default(0),
+  conflict: integer('conflict').default(0),
+  updatedAt: timestamp('updated_at').defaultNow(),
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "chatlife",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "node -e \"console.log('no tests')\""
+  },
+  "dependencies": {
+    "drizzle-orm": "^0.30.0",
+    "postgres": "^3.3.5"
+  }
+}

--- a/supabase/functions/wechat-login/index.ts
+++ b/supabase/functions/wechat-login/index.ts
@@ -1,0 +1,88 @@
+// deno-lint-ignore-file no-explicit-any
+import { serve } from "https://deno.land/std@0.203.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import * as jose from "https://esm.sh/jose@5";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!; // admin 权限
+const JWT_SECRET = Deno.env.get("JWT_SECRET")!; // Supabase 项目 JWT Secret（用于自签）
+const WECHAT_APPID = Deno.env.get("WECHAT_APPID")!;
+const WECHAT_SECRET = Deno.env.get("WECHAT_SECRET")!;
+
+const supabaseAdmin = createClient(SUPABASE_URL, SERVICE_KEY, {
+  auth: { persistSession: false }
+});
+
+async function fetchWeChatToken(code: string) {
+  const url = `https://api.weixin.qq.com/sns/oauth2/access_token?appid=${WECHAT_APPID}&secret=${WECHAT_SECRET}&code=${code}&grant_type=authorization_code`;
+  const res = await fetch(url);
+  const data = await res.json();
+  if (!res.ok || data.errcode) throw new Error(`wechat token error: ${JSON.stringify(data)}`);
+  return data as { access_token: string; openid: string; unionid?: string };
+}
+
+async function upsertUser(wechat: { openid: string; unionid?: string }) {
+  // 用 wechat:openid 作为外部 id，创建/查找 auth.users
+  const externalId = `wechat:${wechat.openid}`;
+  const email = `${wechat.openid}@wechat.local`;
+
+  // 查是否存在
+  const { data: existing } = await supabaseAdmin.auth.admin.listUsers({ page: 1, perPage: 1, filter: `email.eq.${email}` as any });
+  let userId: string | null = existing?.users?.[0]?.id ?? null;
+
+  if (!userId) {
+    const { data, error } = await supabaseAdmin.auth.admin.createUser({
+      email,
+      email_confirm: true,
+      user_metadata: {
+        provider: "wechat",
+        openid: wechat.openid,
+        unionid: wechat.unionid ?? null,
+      }
+    });
+    if (error) throw error;
+    userId = data.user?.id ?? null;
+  }
+  if (!userId) throw new Error("failed to ensure user");
+  return { userId, email };
+}
+
+async function signCustomJwt(userId: string) {
+  const alg = "HS256";
+  const key = new TextEncoder().encode(JWT_SECRET);
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    sub: userId,
+    exp: now + 3600,
+    iat: now,
+    aud: "authenticated",
+    role: "authenticated",
+  };
+  const jwt = await new jose.SignJWT(payload).setProtectedHeader({ alg }).sign(key);
+  return jwt;
+}
+
+serve(async (req) => {
+  try {
+    if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
+    const { code } = await req.json();
+    if (!code) return new Response(JSON.stringify({ error: "missing code" }), { status: 400 });
+
+    const token = await fetchWeChatToken(code);
+    const { userId, email } = await upsertUser({ openid: token.openid, unionid: token.unionid });
+
+    const access_token = await signCustomJwt(userId);
+
+    // 同步业务表
+    await supabaseAdmin.from("app.users").upsert({ uid: userId, display_name: email.split("@")[0] }).select();
+
+    return new Response(JSON.stringify({
+      access_token,
+      token_type: "bearer",
+      expires_in: 3600,
+      user: { id: userId, email }
+    }), { headers: { "Content-Type": "application/json" } });
+  } catch (e) {
+    return new Response(JSON.stringify({ error: String(e) }), { status: 400, headers: { "Content-Type": "application/json" } });
+  }
+});

--- a/supabase/seed/001_init.sql
+++ b/supabase/seed/001_init.sql
@@ -1,0 +1,107 @@
+-- 扩展
+create extension if not exists pgcrypto;
+create extension if not exists "uuid-ossp";
+create extension if not exists vector; -- pgvector
+
+-- Schema
+create schema if not exists app;
+
+-- 用户表（业务侧）
+create table if not exists app.users (
+  uid uuid primary key references auth.users(id) on delete cascade,
+  display_name text,
+  avatar_url text,
+  locale text default 'en',
+  tz text default 'Asia/Singapore',
+  created_at timestamptz default now()
+);
+
+-- 运行/人生存档
+create table if not exists app.runs (
+  id uuid primary key default gen_random_uuid(),
+  owner_uid uuid not null references auth.users(id) on delete cascade,
+  universe text not null,
+  seed_profile jsonb not null,
+  state jsonb default '{}',
+  version text default 'v1',
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+create index if not exists idx_runs_owner on app.runs(owner_uid);
+
+-- 聊天与消息
+create table if not exists app.chats (
+  id uuid primary key default gen_random_uuid(),
+  run_id uuid not null references app.runs(id) on delete cascade,
+  title text,
+  stage text,
+  last_message_at timestamptz,
+  created_at timestamptz default now()
+);
+create index if not exists idx_chats_run on app.chats(run_id);
+
+create table if not exists app.messages (
+  id bigint generated always as identity primary key,
+  chat_id uuid not null references app.chats(id) on delete cascade,
+  role text check (role in ('user','assistant','system')),
+  content text not null,
+  meta jsonb,
+  tokens_in int default 0,
+  tokens_out int default 0,
+  llm_model text,
+  status text default 'complete',
+  created_at timestamptz default now()
+);
+create index if not exists idx_messages_chat_ts on app.messages(chat_id, created_at);
+
+-- NPC/模板/关系
+create table if not exists app.npcs (
+  id uuid primary key default gen_random_uuid(),
+  universe text not null,
+  archetype text not null,
+  persona jsonb not null,
+  memory_vec vector(1536),
+  created_at timestamptz default now()
+);
+
+create table if not exists app.templates (
+  id uuid primary key default gen_random_uuid(),
+  universe text not null,
+  version text not null,
+  checksum text,
+  files jsonb,
+  created_at timestamptz default now()
+);
+
+create table if not exists app.relationships (
+  id uuid primary key default gen_random_uuid(),
+  run_id uuid not null references app.runs(id) on delete cascade,
+  subject_type text not null,
+  subject_id uuid not null,
+  intimacy int default 0,
+  trust int default 0,
+  conflict int default 0,
+  updated_at timestamptz default now()
+);
+create index if not exists idx_rel_run on app.relationships(run_id);
+
+-- RLS 策略
+alter table app.runs enable row level security;
+create policy if not exists runs_owner_isolation on app.runs
+  for all using (owner_uid = auth.uid()) with check (owner_uid = auth.uid());
+
+alter table app.chats enable row level security;
+create policy if not exists chats_run_owner on app.chats
+  for all using (
+    exists(select 1 from app.runs r where r.id = run_id and r.owner_uid = auth.uid())
+  ) with check (
+    exists(select 1 from app.runs r where r.id = run_id and r.owner_uid = auth.uid())
+  );
+
+alter table app.messages enable row level security;
+create policy if not exists messages_chat_owner on app.messages
+  for all using (
+    exists(select 1 from app.chats c join app.runs r on r.id=c.run_id where c.id=chat_id and r.owner_uid=auth.uid())
+  ) with check (
+    exists(select 1 from app.chats c join app.runs r on r.id=c.run_id where c.id=chat_id and r.owner_uid=auth.uid())
+  );


### PR DESCRIPTION
## Summary
- add SQL schema, indexes, and RLS policies for core tables
- introduce WeChat login edge function that creates users and signs JWT
- add Drizzle ORM client and schema for Supabase database
- document basic Supabase setup steps and Drizzle usage

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/drizzle-orm)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b929761264832bb123c01486c39ba1